### PR TITLE
BE-2058 Fix xcodebuild command

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -7,6 +7,7 @@ require 'fileutils'
 require 'uri'
 require 'xcodeproj'
 require 'securerandom'
+require 'English'
 
 ###### Enviroment Variable Check
 def env_has_key(key)

--- a/main.rb
+++ b/main.rb
@@ -120,6 +120,7 @@ def run_command(command,skip_abort)
 end
 
 def run_command_simple(command)
+  puts "@@[command] #{command}"
   return if system(command)
 
   abort_script("@@[error] Unexpected exit with code #{$CHILD_STATUS.exitstatus}.

--- a/main.rb
+++ b/main.rb
@@ -127,9 +127,9 @@ def run_command_simple(command)
   command.concat(stderr_file)
   return if system(command)
 
+  exit_code = $CHILD_STATUS.exitstatus
   system("cat #{stderr_file}")
-  abort_script("@@[error] Unexpected exit with code #{$CHILD_STATUS.exitstatus}.
-    Check logs for details.")
+  abort_script("@@[error] Unexpected exit with code #{exit_code}. Check logs for details.")
 end
 
 def abort_script(error)

--- a/main.rb
+++ b/main.rb
@@ -121,8 +121,12 @@ end
 
 def run_command_simple(command)
   puts "@@[command] #{command}"
+  stderr_file = "#{ENV['AC_TEMP_DIR']}/.command.stderr.log"
+  command.concat(' 2>')
+  command.concat(stderr_file)
   return if system(command)
 
+  system("cat #{stderr_file}")
   abort_script("@@[error] Unexpected exit with code #{$CHILD_STATUS.exitstatus}.
     Check logs for details.")
 end

--- a/main.rb
+++ b/main.rb
@@ -119,6 +119,13 @@ def run_command(command,skip_abort)
   end
 end
 
+def run_command_simple(command)
+  return if system(command)
+
+  abort_script("@@[error] Unexpected exit with code #{$CHILD_STATUS.exitstatus}.
+    Check logs for details.")
+end
+
 def abort_script(error)
   abort("#{error}")
 end
@@ -394,7 +401,7 @@ def export_archive(export_options)
     command_export.concat(" ")
     command_export.concat("-authenticationKeyIssuerID #{issuer_id}")
   end
-  run_command(command_export,false);
+  run_command_simple(command_export)
 
   begin
     #Write Environment Variable
@@ -460,8 +467,7 @@ def archive()
     command.concat(" -project \"#{$project_full_path}\"")
   end
 
-
-  run_command(command,false)
+  run_command_simple(command)
 end
 
 def get_bundle_identifiers_and_embedded_provisioning_profiles(path)


### PR DESCRIPTION
For `xcodebuild` execution, I changed the implementation from `Open3.popen3(command)` to `system(command)`.

It's runtime is compatible with "run_command()".
- When `xcodebuild` run is success, print only "stdout".
- When `xcodebuild` run is failure, print "stdout" and "stderr".